### PR TITLE
Leading spaces in header value not stripped

### DIFF
--- a/human_curl/core.py
+++ b/human_curl/core.py
@@ -746,7 +746,7 @@ class Response(object):
                 if not header:
                     continue
                 elif not header.startswith("HTTP"):
-		    field, value = map(lambda u: u.strip(), header.split(":", 1))
+                    field, value = map(lambda u: u.strip(), header.split(":", 1))
                     if field.startswith("Location"):
                         # maybe not good
                         if not value.startswith("http"):


### PR DESCRIPTION
Leading spaces in header value not stripped while parsing. This causes incorrect url joining in Request.history when url in Location header starts with http:// (" http://<...>".startswith('http') == False), so history list looks like this 

```
['http://somedomain.com http://anotherdomain.com/someurl']
```
