### PR TITLE
Tried to fix ValueError: signal only works in main thread

### DIFF
--- a/human_curl/core.py
+++ b/human_curl/core.py
@@ -42,7 +42,9 @@ try:
     import platform
     if platform.system().lower() != 'windows':
         import signal
-        signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+        from threading import current_thread
+        if current_thread().name == 'MainThread':
+            signal.signal(signal.SIGPIPE, signal.SIG_IGN)
 except ImportError:
     pass
 


### PR DESCRIPTION
I got the error when I was working in threads:

``` python
  File "/usr/local/lib/python2.7/dist-packages/human_curl/__init__.py", line 55, in <module>
    from .methods import get, put, head, post, delete, request, options
  File "/usr/local/lib/python2.7/dist-packages/human_curl/methods.py", line 12, in <module>
    from .core import Request
  File "/usr/local/lib/python2.7/dist-packages/human_curl/core.py", line 46, in <module>
    signal.signal(signal.SIGPIPE, signal.SIG_IGN)
ValueError: signal only works in main thread
```

So I tried to solve it. I'm not sure that my fix is absolutely correct but it works for me.
