### PR TITLE
fix send files list as list

### DIFF
--- a/human_curl/core.py
+++ b/human_curl/core.py
@@ -233,7 +233,7 @@ class Request(object):
         else:
             raise ValueError("auth must be list, tuple or dict, not %s" % type(auth))
 
-        # forllow by location header field
+        # follow by location header field
         self._allow_redirects = allow_redirects
         self._max_redirects = max_redirects
 
@@ -552,7 +552,7 @@ class Request(object):
         if self._method in ("POST", "PUT"):
             if self._files is not None:
                 post_params = self._files
-                if isinstance(self._data, (TupleType, DictType)):
+                if isinstance(self._data, (TupleType, ListType, DictType)):
                     post_params.extend(data_wrapper(self._data))
                 opener.setopt(opener.HTTPPOST, post_params)
             else:

--- a/human_curl/utils.py
+++ b/human_curl/utils.py
@@ -282,7 +282,7 @@ def data_wrapper(data):
 def make_curl_post_files(data):
     """Convert parameters dict, list or tuple to cURL style tuple
     """
-    if isinstance(data, TupleType):
+    if isinstance(data, (TupleType, ListType)):
         iterator = data
     elif isinstance(data, DictType):
         iterator = data.iteritems()


### PR DESCRIPTION
comment for make_curl_post_files(data): says
"""Convert parameters dict, list or tuple to cURL style tuple"""
but list actually call's an error:
raise ValueError("%s argument must be list, tuple or dict, not %s" %
                         ("make_curl_post_files", type(data)))

Also in agreed with this pull request https://github.com/Lispython/human_curl/pull/14:

due to this code

``` python
class Request(object):
    def __init___(self, ...):
        ...
        # String, dict, tuple, list
        if isinstance(data, (StringTypes, NoneType)):
            self._data = data
        else:
            self._data = data_wrapper(data)

def data_wrapper(data):
    """Convert data to list and returns
    """
    ...

 def build_opener(self, url, opener=None):
     ...
        if self._files is not None:
                post_params = self._files
                if isinstance(self._data, (TupleType, DictType)):
                    post_params.extend(data_wrapper(self._data))
                opener.setopt(opener.HTTPPOST, post_params)
```

so we will never get to post_params.extend(data_wrapper(self._data)) if we are trying to send some files, because data is going to be wrapped in list in Request constructor.
