### PR TITLE
Raw params data send

### DIFF
--- a/human_curl/methods.py
+++ b/human_curl/methods.py
@@ -19,7 +19,7 @@ def request(method, url, params=None, data=None, headers=None, cookies=None,
             files=None, timeout=None, allow_redirects=False, max_redirects=5, proxy=None,
             auth=None, network_interface=None, use_gzip=None, validate_cert=False,
             ca_certs=None, cert=None, debug=False, user_agent=None, ip_v6=False,
-            hooks=None, options=None, callback=None, return_response=True, **kwargs):
+            hooks=None, options=None, callback=None, return_response=True, encode_query=True, **kwargs):
     """Construct and sends a Request object. Returns :class `Response`.
 
     Arguments:
@@ -65,7 +65,7 @@ def request(method, url, params=None, data=None, headers=None, cookies=None,
         files=files, timeout=timeout, allow_redirects=allow_redirects, max_redirects=max_redirects, proxy=proxy,
         auth=auth, network_interface=network_interface, use_gzip=use_gzip, validate_cert=validate_cert,
         ca_certs=ca_certs, cert=cert, debug=debug, user_agent=user_agent, ip_v6=ip_v6, options=options,
-        callback=callback, **kwargs)
+        callback=callback, encode_query=encode_query, **kwargs)
 
     # TODO: add hooks
     r = Request(**args)

--- a/human_curl/utils.py
+++ b/human_curl/utils.py
@@ -587,3 +587,19 @@ def curry(fn, *cargs, **ckwargs):
         d.update(fkwargs)
         return fn(*(cargs + fargs), **d)
     return call_fn
+
+
+def urlnoencode(query):
+    """Convert a sequence of two-element tuples or dictionary into a URL query string without url-encoding.
+    """
+    l = []
+    arg = "%s=%s"
+
+    if hasattr(query, "items"):
+        # mapping objects
+        query = query.items()
+
+    for k, v in query:
+        l.append(arg % (k, v))
+
+    return "&".join(l)

--- a/tests.py
+++ b/tests.py
@@ -300,7 +300,6 @@ class RequestsTestCase(BaseTestCase):
         self.assertEquals(json_response['username'], username)
         self.assertEquals(json_response['auth-type'], 'basic')
 
-
     def test_digest_auth(self):
         username = uuid.uuid4().get_hex()
         password =  uuid.uuid4().get_hex()
@@ -313,7 +312,6 @@ class RequestsTestCase(BaseTestCase):
         self.assertEquals(json_response['password'], password)
         self.assertEquals(json_response['username'], username)
         self.assertEquals(json_response['auth-type'], 'digest')
-
 
     def test_auth_denied(self):
         username = "hacker_username"
@@ -389,7 +387,6 @@ class RequestsTestCase(BaseTestCase):
         r2 = requests.get("http://h.wrttn.me/get", hooks={'response_hook': response_hook})
         self.assertEquals(r2._status_code, 700)
 
-
     def test_json_response(self):
         random_key = "key_" + uuid.uuid4().get_hex()[:10]
         random_value1 = "value_" + uuid.uuid4().get_hex()
@@ -405,6 +402,24 @@ class RequestsTestCase(BaseTestCase):
         self.assertEquals(json_response, r.json)
         self.assertTrue(random_value1 in r.json['args'][random_key])
         self.assertTrue(random_value2 in r.json['args'][random_key])
+
+    def test_get_encode_query(self):
+        params = {'q': 'value with space and @'}
+        key, value = 'email', 'user@domain.com'
+        response = requests.get(build_url("get""?%s=%s" % (key, value)), params=params)
+        self.assertEquals(response.status_code, 200)
+        self.assertEqual("{0}/get?email=user%40domain.com&q=value+with+space+and+%40".format(HTTP_TEST_URL), response.request._url)
+        args = json.loads(response.content)['args']
+        self.assertEquals(args['q'][0], params['q'])
+        self.assertEquals(args[key][0], value)
+
+    def test_get_no_encode_query(self):
+        params = {'q': 'value with space and @'}
+        key, value = 'email', 'user@domain.com'
+        response = requests.get(build_url("get""?%s=%s" % (key, value)), params=params, encode_query=False)
+        self.assertEquals(response.status_code, 502)
+        self.assertEqual("{0}/get?email=user@domain.com&q=value with space and @".format(HTTP_TEST_URL), response.request._url)
+
 
 class ResponseTestCase(BaseTestCase):
 
@@ -1046,7 +1061,6 @@ class AsyncTestCase(BaseTestCase):
                                 fail_callback=fail_callback)
         self.assertEquals(len(async_client_global._data_queue), 2)
         async_client_global.start(process_func)
-
 
     def test_setup_opener(self):
         async_client = AsyncClient()


### PR DESCRIPTION
Sometimes it's necessary to have ability to send raw parameters with get request. (especially in testing)

By default there going to be no changes, except fix:
for parameters that were going in url, like, http://h.wrttn.me?key=value, key and value weren't encoded
but now they are, look in tests.

For send a raw request, without url encoding, just need to pass a encode_url=True arg to Request.
