### PR TITLE
Use multipart only if it is present in headers.

### DIFF
--- a/human_curl/core.py
+++ b/human_curl/core.py
@@ -598,11 +598,14 @@ class Request(object):
                         opener.setopt(pycurl.POST, True)
                         opener.setopt(pycurl.POSTFIELDSIZE, len(self._data))
                 elif isinstance(self._data, (TupleType, ListType, DictType)):
-                    # use multipart/form-data;
-                    opener.setopt(opener.HTTPPOST, data_wrapper(self._data))
-
-                    # use postfields to send vars as application/x-www-form-urlencoded
-                    # opener.setopt(pycurl.POSTFIELDS, encoded_data)
+                    headers = dict(self._headers or [])
+                    if 'multipart' in headers.get('Content-Type', ''):
+                        # use multipart/form-data;
+                        opener.setopt(opener.HTTPPOST, data_wrapper(self._data))
+                    else:
+                        # use postfields to send vars as application/x-www-form-urlencoded
+                        encoded_data = urlencode(self._data, doseq=True)
+                        opener.setopt(pycurl.POSTFIELDS, encoded_data)
 
         if isinstance(self._options, (TupleType, ListType)):
             for key, value in self._options:

--- a/tests.py
+++ b/tests.py
@@ -345,6 +345,19 @@ class RequestsTestCase(BaseTestCase):
         self.assertTrue(random_value1 in json_response['args'][random_key])
         self.assertTrue(random_value2 in json_response['args'][random_key])
 
+    def test_multipart_post_data(self):
+        random_key = "key_" + uuid.uuid4().get_hex()[:10]
+        random_value = "value_" + uuid.uuid4().get_hex()
+        r = requests.post(
+            build_url("post"),
+            data={random_key: random_value},
+            headers={'Content-Type': 'multipart/form-data'})
+
+        json_response = json.loads(r.content)
+        content_type = json_response['headers']['Content-Type']
+        self.assertTrue(random_value in json_response['args'][random_key])
+        self.assertTrue('multipart/form-data; boundary=-' in content_type)
+
     def test_redirect(self):
         r = requests.get(build_url("redirect", '3'), allow_redirects=True)
         self.assertEquals(r.status_code, 200)


### PR DESCRIPTION
Human CURL makes a multipart POST request by default. This is not correct, and should happen only when a file upload is taking place or you actually specify the headers that way.

Please take a look and let me know if this needs any other work.
Thanks.
