### PR TITLE
Fix build with recent Python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ pip-log.txt
 *.egg-info*
 dist/*
 _build/*
+build/*

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from setuptools import Command, setup
 try:
     readme_content = open(os.path.join(os.path.abspath(
         os.path.dirname(__file__)), "README.rst")).read()
-except Exception, e:
+except Exception as e:
     print(e)
     readme_content = __doc__
 


### PR DESCRIPTION
According to Python Docs "Exception,e" is Python before 2.7 and incompatible with Python 3, currently "Exception as e" should be used. This pull requests changes this for the setup.py script which enables it to build/install again.